### PR TITLE
Created a check-error gitHub action

### DIFF
--- a/.github/workflows/check-error.yml
+++ b/.github/workflows/check-error.yml
@@ -1,0 +1,32 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Check
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the production branch
+on:
+  push:
+    branches: [ production ]
+  pull_request:
+    branches: [ production ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  check:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      # Runs a single command using the runners shell
+      - name: Python Linter
+        uses: sunnysid3up/python-linter@v0.1-beta.7
+        with:
+          strict: "medium"
+
+
+     


### PR DESCRIPTION
Related issue #84 

- Used the Python Linter Bot GitHub Action instead of a pre-commit hook
- More config needed but so far, this does the basic job of checking for syntax errors allowing people to see where it errors out. 