### PR TITLE
Attempted fix for alt text

### DIFF
--- a/tweet.py
+++ b/tweet.py
@@ -47,7 +47,7 @@ def main():
         image = api.media_upload(image_path)
         # add alt-text
         api.create_media_metadata(
-            str(image.media_id), alt_text=tweet_content["text"])
+            media_id=image.media_id, alt_text=tweet_content["text"])
     except Exception as error:
         print(f"An error occurred while generating image. reason: {error}")
 


### PR DESCRIPTION
Made media id a named parameter in the call to create_media_metadata in an attempt to make alt text work 