### PR TITLE
Update tweepy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask==1.0.2
-tweepy~=3.8.0
+tweepy~=3.9.0
 pillow
 # reference: https://note.nkmk.me/en/python-pip-install-requirements/


### PR DESCRIPTION
# For #105 Add alt text to images
create_media_metadata was added in version 3.9.0 of tweepy, so currently it does not work, updating to the latest version should enable alt text for images