### PR TITLE
fix: Fixed Typo in words_dir/tweet_nouns.py

### DIFF
--- a/words_dir/tweet_nouns.py
+++ b/words_dir/tweet_nouns.py
@@ -1060,7 +1060,7 @@ nouns = [
     'baggy pair of trousers',
 
     # ridiculous purposefully misspelled aminals
-    'snek',   # snkae
+    'snek',   # snake
     'danger noodle',  # snake
     'barkly loaf',  # corgi
     'water sausage',  # otter


### PR DESCRIPTION
Fixed typo: "snkae",  for on-going First-Timer Issue #112