### PR TITLE
Fix event date check for annual events

### DIFF
--- a/tweet_history.py
+++ b/tweet_history.py
@@ -29,7 +29,7 @@ def tweet_historicat_event():
     month_and_day = today[5:]  # slice off the first 5 characters
 
     # make a list of the events that match month_and_day
-    list_of_history_tweets = [key + ":\n" + val for key, val in events.items() if month_and_day in key]
+    list_of_history_tweets = [key + ":\n" + val for key, val in events.items() if month_and_day == key[5:]]
     length_list_history_tweets = len(list_of_history_tweets)
 
     '''if list has multiple events for the same month and day,


### PR DESCRIPTION
Closes #297 
As described in #297 the bot would post annual events on days other than the correct date, this was occurring because it would search today's 'MM-DD' in the event's 'YYYY-MM-DD'. This PR fixes this with a small correction to make the bot compare today's date and months with the event's date and months i.e. event_date[5:0], to remove the YYYY- portion before comparing.