### PR TITLE
Update tweet_nouns.py (Comment typo and organization)

### DIFF
--- a/words_dir/tweet_nouns.py
+++ b/words_dir/tweet_nouns.py
@@ -1052,27 +1052,27 @@ nouns = [
     'wicket',
 
     # fashion trends
-    'tight-rolled pant legs',
     'asymmetrical undercut',
-    'septum piercing',
-    'rolled pant legs',
-    'folded shirt sleeve',
-    'cuffed jeans',
-    'oversized jeans',
-    'ripped stockings',
-    'pair of faux fur sandals',
-    'bucket hats',
     'baggy pair of trousers',
+    'bucket hats',
+    'cuffed jeans',
+    'folded shirt sleeve',
+    'oversized jeans',
+    'pair of faux fur sandals',
+    'ripped stockings',
+    'rolled pant legs',
+    'septum piercing',
+    'tight-rolled pant legs',
 
-    # ridiculous purposefully misspelled aminals
-    'snek',   # snake
-    'danger noodle',  # snake
+    # ridiculous purposefully misspelled animals
     'barkly loaf',  # corgi
-    'water sausage',  # otter
-    'kitteh',  # kitty
-    'speed sausage',  # corgi
+    'danger noodle',  # snake
     'doggo 🐶',  # dog
+    'kitteh',  # kitty
     'pupper 🐶',  # puppy
+    'snek',   # snake
+    'speed sausage',  # corgi
+    'water sausage',  # otter
 
     # queer things
     '@autostraddle article',


### PR DESCRIPTION
Reorganizes the "fashion trends" and "ridiculous purposefully misspelled animals" sections to be in alphabetical order. Also corrects the comment denoting the former to say "animals" rather than "aminals".

Would probably be linked to issue #112 (?)

This is for hacktoberfest, so the hacktoberfest-accepted label would be appreciated (if it's still relevant?).